### PR TITLE
fix(ci): repair publish workflow YAML heredoc parsing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,28 +29,29 @@ jobs:
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          skip_publish="$(python - <<'PY'
-          import json
-          import os
-          import urllib.error
-          import urllib.request
+          skip_publish="$(
+            python - <<'PY'
+            import json
+            import os
+            import urllib.error
+            import urllib.request
 
-          package_name = os.environ["PACKAGE_NAME"]
-          version = os.environ["RELEASE_TAG"].lstrip("v")
-          url = f"https://pypi.org/pypi/{package_name}/json"
+            package_name = os.environ["PACKAGE_NAME"]
+            version = os.environ["RELEASE_TAG"].lstrip("v")
+            url = f"https://pypi.org/pypi/{package_name}/json"
 
-          try:
-              with urllib.request.urlopen(url, timeout=15) as response:
-                  payload = json.load(response)
-          except urllib.error.HTTPError as error:
-              if error.code == 404:
-                  print("false")
-              else:
-                  raise
-          else:
-              releases = payload.get("releases", {})
-              print("true" if releases.get(version) else "false")
-          PY
+            try:
+                with urllib.request.urlopen(url, timeout=15) as response:
+                    payload = json.load(response)
+            except urllib.error.HTTPError as error:
+                if error.code == 404:
+                    print("false")
+                else:
+                    raise
+            else:
+                releases = payload.get("releases", {})
+                print("true" if releases.get(version) else "false")
+            PY
           )"
           echo "skip_publish=${skip_publish}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Summary
- Fix invalid YAML parsing in `.github/workflows/publish.yml`.
- Make the PyPI version-check heredoc safe inside shell command substitution.

## Why
- GitHub Actions reported an invalid workflow syntax error at line 33, which blocked the publish route.

## Verification
- Workflow YAML parses successfully after this change.
