### PR TITLE
fix(ci): stop release churn and publish from main pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,16 +6,20 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
-  publish-pypi:
+  resolve-version:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -36,11 +40,23 @@ jobs:
           echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
           echo "release_tag=v${package_version}" >> "${GITHUB_OUTPUT}"
 
+  publish-pypi:
+    if: github.ref == 'refs/heads/main'
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Check if version already exists on PyPI
         id: pypi_check
         env:
           PACKAGE_NAME: azure-pipeline-validator
-          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           set -euo pipefail
           skip_publish="$(
@@ -96,6 +112,8 @@ jobs:
         run: echo "Version already published on PyPI; skipping publish step."
 
   publish-ghcr-oci:
+    if: github.ref == 'refs/heads/main'
+    needs: resolve-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -103,22 +121,6 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Determine package version
-        id: version
-        run: |
-          set -euo pipefail
-          package_version="$(
-            python - <<'PY'
-            import tomllib
-            from pathlib import Path
-
-            payload = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-            print(payload["project"]["version"])
-            PY
-          )"
-          echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
-          echo "release_tag=v${package_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
@@ -136,7 +138,7 @@ jobs:
       - name: Compute OCI reference
         id: oci
         env:
-          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          RELEASE_TAG: ${{ needs.resolve-version.outputs.release_tag }}
         run: |
           set -euo pipefail
           owner_lc="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
 name: Publish
 
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +17,32 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Check out release tag
+      - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.release.tag_name }}
+
+      - name: Determine package version
+        id: version
+        run: |
+          set -euo pipefail
+          package_version="$(
+            python - <<'PY'
+            import tomllib
+            from pathlib import Path
+
+            payload = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+            print(payload["project"]["version"])
+            PY
+          )"
+          echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=v${package_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Check if version already exists on PyPI
         id: pypi_check
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
           PACKAGE_NAME: azure-pipeline-validator
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          version="${RELEASE_TAG#v}"
           skip_publish="$(
             python - <<'PY'
             import json
@@ -37,7 +51,7 @@ jobs:
             import urllib.request
 
             package_name = os.environ["PACKAGE_NAME"]
-            version = os.environ["RELEASE_TAG"].lstrip("v")
+            version = os.environ["PACKAGE_VERSION"]
             url = f"https://pypi.org/pypi/{package_name}/json"
 
             try:
@@ -87,10 +101,24 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Check out release tag
+      - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.release.tag_name }}
+
+      - name: Determine package version
+        id: version
+        run: |
+          set -euo pipefail
+          package_version="$(
+            python - <<'PY'
+            import tomllib
+            from pathlib import Path
+
+            payload = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+            print(payload["project"]["version"])
+            PY
+          )"
+          echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=v${package_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
@@ -108,7 +136,7 @@ jobs:
       - name: Compute OCI reference
         id: oci
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         run: |
           set -euo pipefail
           owner_lc="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -28,28 +28,8 @@
       "hidden": false
     },
     {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": false
-    },
-    {
-      "type": "chore",
-      "section": "Chores",
-      "hidden": false
-    },
-    {
       "type": "refactor",
       "section": "Refactoring",
-      "hidden": false
-    },
-    {
-      "type": "test",
-      "section": "Tests",
-      "hidden": false
-    },
-    {
-      "type": "ci",
-      "section": "CI",
       "hidden": false
     }
   ]


### PR DESCRIPTION
## Summary
- Stop release-please churn by limiting release-notes sections to releasable commit types: `feat`, `fix`, `perf`, `deps`, `refactor`.
- Change publish trigger from `release.published` to `push` on `main` (plus `workflow_dispatch`).
- Derive package version from `pyproject.toml` at runtime and use it for PyPI/GHCR checks.

## Why
- Release PRs were chaining continuously (`0.1.1 -> 0.1.2 -> 0.1.3 -> 0.1.4`) and not matching desired behavior.
- Publish should run from merges to `main` and only publish when a new package version is present.

## Verification
- Workflow YAML parses successfully.
- Release-please config JSON parses successfully.
- `uv run python -m pytest` passed (`163` tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Publishing workflow now triggers on main branch pushes and manual dispatch, enabling more frequent releases.
  * Version detection now reads directly from project configuration for consistency across publishing steps.
  * Release changelog configuration streamlined to focus on key change categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->